### PR TITLE
Rename library navigation tab to Lunaby

### DIFF
--- a/lib/src/ui/pages/home_page.dart
+++ b/lib/src/ui/pages/home_page.dart
@@ -316,7 +316,7 @@ class _HomeNavigationBarState extends State<_HomeNavigationBar> {
         ),
         NavigationDestination(
           icon: Icon(Icons.library_books_outlined),
-          label: 'Library',
+          label: 'Lunaby',
         ),
         NavigationDestination(
           icon: Icon(Icons.receipt_long_outlined),


### PR DESCRIPTION
## Summary
- update the home navigation bar tab label so it reads "Lunaby" instead of "Library"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15f83f6208328b6b1cb32de0d5a15